### PR TITLE
added hack line for libxslt

### DIFF
--- a/openjdk-10/Dockerfile
+++ b/openjdk-10/Dockerfile
@@ -90,6 +90,8 @@ RUN echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" >> 
   apt-get install -y git && \
   apt-get clean all && \
   /usr/bin/git --version
+#Hack line for xlocale.h, remove it once libxslt is updated to 1.1.33: https://github.com/GNOME/libxslt/commit/8b4babb8f742a1a189df4c4569e68eda308df68f
+RUN ln -s /usr/include/locale.h /usr/include/xlocale.h
 ADD requirements.txt /tmp/requirements.txt
 ADD pyenv.sh /tmp/pyenv.sh
 RUN export DEBIAN_FRONTEND=noninteractive TERM=linux && \

--- a/openjdk-11/Dockerfile
+++ b/openjdk-11/Dockerfile
@@ -90,6 +90,8 @@ RUN echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" >> 
   apt-get install -y git && \
   apt-get clean all && \
   /usr/bin/git --version
+#Hack line for xlocale.h, remove it once libxslt is updated to 1.1.33: https://github.com/GNOME/libxslt/commit/8b4babb8f742a1a189df4c4569e68eda308df68f
+RUN ln -s /usr/include/locale.h /usr/include/xlocale.h
 ADD requirements.txt /tmp/requirements.txt
 ADD pyenv.sh /tmp/pyenv.sh
 RUN export DEBIAN_FRONTEND=noninteractive TERM=linux && \

--- a/openjdk-7/Dockerfile
+++ b/openjdk-7/Dockerfile
@@ -90,6 +90,8 @@ RUN echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" >> 
   apt-get install -y git && \
   apt-get clean all && \
   /usr/bin/git --version
+#Hack line for xlocale.h, remove it once libxslt is updated to 1.1.33: https://github.com/GNOME/libxslt/commit/8b4babb8f742a1a189df4c4569e68eda308df68f
+RUN ln -s /usr/include/locale.h /usr/include/xlocale.h
 ADD requirements.txt /tmp/requirements.txt
 ADD pyenv.sh /tmp/pyenv.sh
 RUN export DEBIAN_FRONTEND=noninteractive TERM=linux && \

--- a/openjdk-8/Dockerfile
+++ b/openjdk-8/Dockerfile
@@ -90,6 +90,8 @@ RUN echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" >> 
   apt-get install -y git && \
   apt-get clean all && \
   /usr/bin/git --version
+#Hack line for xlocale.h, remove it once libxslt is updated to 1.1.33: https://github.com/GNOME/libxslt/commit/8b4babb8f742a1a189df4c4569e68eda308df68f
+RUN ln -s /usr/include/locale.h /usr/include/xlocale.h
 ADD requirements.txt /tmp/requirements.txt
 ADD pyenv.sh /tmp/pyenv.sh
 RUN export DEBIAN_FRONTEND=noninteractive TERM=linux && \

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -90,6 +90,8 @@ RUN echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" >> 
   apt-get install -y git && \
   apt-get clean all && \
   /usr/bin/git --version
+#Hack line for xlocale.h, remove it once libxslt is updated to 1.1.33: https://github.com/GNOME/libxslt/commit/8b4babb8f742a1a189df4c4569e68eda308df68f
+RUN ln -s /usr/include/locale.h /usr/include/xlocale.h
 ADD requirements.txt /tmp/requirements.txt
 ADD pyenv.sh /tmp/pyenv.sh
 RUN export DEBIAN_FRONTEND=noninteractive TERM=linux && \


### PR DESCRIPTION
The following line was added to the Dockerfile:
RUN ln -s /usr/include/locale.h /usr/include/xlocale.h 

We need to remove it once libxslt is updated to 1.1.33: 
https://github.com/GNOME/libxslt/commit/8b4babb8f742a1a189df4c4569e68eda308df68f