### PR TITLE
Base image for building python libraries

### DIFF
--- a/fusion5/gradle-python-docker-builder/Dockerfile
+++ b/fusion5/gradle-python-docker-builder/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3
+
+USER root
+RUN apt-get update && \
+apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common && \
+curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
+apt-get update && \
+apt-get install -y docker-ce && \
+apt-get clean && \
+groupadd jenkins -g 7000 && \
+useradd jenkins -d /home/jenkins -m -u 7000 -g docker -G docker -s /bin/bash
+
+USER gradle

--- a/fusion5/gradle-python-docker-builder/Dockerfile
+++ b/fusion5/gradle-python-docker-builder/Dockerfile
@@ -11,4 +11,4 @@ apt-get clean && \
 groupadd jenkins -g 7000 && \
 useradd jenkins -d /home/jenkins -m -u 7000 -g docker -G docker -s /bin/bash
 
-USER gradle
+USER jenkins


### PR DESCRIPTION
* Similar to our java gradle images for docker
* Published this with tag `v0.0.1` manually 
```
cloud-infrastructure.ci-artifactory.lucidworks.com/gradle-python-docker-builder:v0.0.1
```
* CI build working with this image https://ci.lucidworks.com/job/Distributed%20Fusion/job/fusion-jupyter/job/APOLLO-21597/5/console