### PR TITLE
APOLLO-26443-updated docker gradle-jdk11

### DIFF
--- a/fusion5/gradle-jdk11-docker-builder/Dockerfile
+++ b/fusion5/gradle-jdk11-docker-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:6.2.2-jdk11
+FROM gradle:6.6.1-jdk11
 
 USER root
 RUN apt-get update && \


### PR DESCRIPTION
Updated gradle builder to gradle 6.6.1 and jdk to 11.0.8